### PR TITLE
Fix missing error handling in summary function

### DIFF
--- a/netlify/functions/generate-summary.js
+++ b/netlify/functions/generate-summary.js
@@ -30,6 +30,14 @@ Resumo: [resumo completo]`;
       })
     });
 
+    if (!response.ok) {
+      const erroTexto = await response.text();
+      return {
+        statusCode: response.status,
+        body: JSON.stringify({ error: "Erro HTTP da API Gemini", status: response.status, resposta: erroTexto })
+      };
+    }
+
     const data = await response.json();
     const texto = data?.candidates?.[0]?.content?.parts?.map(p => p.text).join(" ").trim();
 


### PR DESCRIPTION
## Summary
- handle errors when calling Gemini API before parsing JSON

## Testing
- `node netlify/functions/generate-summary.js` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6851a2244b148326a1cdb1e4c635f283