### PR TITLE
Add environment-based auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# RSS News API
+
+This project collects RSS feeds and uses Netlify Functions to generate summarized news content.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Create a `.env` file in the project root and define the password used for authentication:
+
+```bash
+NEWS_PASS=your_password_here
+```
+
+Other environment variables required by existing functions (e.g. `GEMINI_API_KEY`) should also be set in this file.
+
+3. Deploy to Netlify or run the functions locally using the Netlify CLI.
+
+## Authentication
+
+The application prompts for a password when loading `index.html`. The value is verified by the Netlify function `auth`. Ensure that `NEWS_PASS` is set in your environment or in `.env` so the authentication succeeds.

--- a/index.html
+++ b/index.html
@@ -34,10 +34,22 @@
   <div class="feeds" id="feedContainer"></div>
   <button id="verMais">🔄 Ver mais notícias</button>
   <script>
+  async function init() {
     const senha = prompt("Digite a senha:");
-  if (senha !== "setic123") {
+  try {
+    const resp = await fetch("/.netlify/functions/auth", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ senha })
+    });
+    const data = await resp.json();
+    if (!data.authorized) {
+      document.body.innerHTML = "<h2>Acesso negado</h2>";
+      throw new Error("Acesso negado");
+    }
+  } catch (e) {
     document.body.innerHTML = "<h2>Acesso negado</h2>";
-    throw new Error("Acesso negado");
+    throw e;
   }
     const feeds = [
       { nome: "Tecnoblog", url: "https://www.tecnoblog.net/feed/" },
@@ -173,6 +185,8 @@
     document.getElementById("searchInput").addEventListener("input", aplicarFiltro);
     document.getElementById("verMais").addEventListener("click", mostrarNoticias);
     carregarFeeds();
+  }
+  init();
   </script>
 </body>
 </html>

--- a/netlify/functions/auth.js
+++ b/netlify/functions/auth.js
@@ -1,0 +1,13 @@
+exports.handler = async function(event) {
+  const body = JSON.parse(event.body || '{}');
+  const password = body.senha;
+  const NEWS_PASS = process.env.NEWS_PASS;
+
+  const authorized = password && NEWS_PASS && password === NEWS_PASS;
+
+  return {
+    statusCode: authorized ? 200 : 401,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+    body: JSON.stringify({ authorized })
+  };
+};


### PR DESCRIPTION
## Summary
- introduce `auth` Netlify function to verify password using env variable `NEWS_PASS`
- update `index.html` to call the new auth function instead of hard-coded check
- document how to set `NEWS_PASS` in `.env`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3fb90f48326aa8a16cfefc3ba16